### PR TITLE
Add SEOengine.ai Black Friday deal

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,12 @@ Stay secure without breaking the bank! This repository curates a list of exclusi
   - **End Date:** December 5th
 
 
+- **SEOengine.ai:** AI-powered SEO tool with 5 specialized agents for AEO-optimized content creation with E-E-A-T compliance
+  - **Link:** [SEOengine.ai](https://seoengine.ai)
+  - **Discount Code:** BLACKFRIDAY
+  - **Discount:** 35% OFF
+  - **End Date:** December 7, 2023
+
 ## Hardware
 - [Example VPN Deal 1](link)
 - [Example VPN Deal 2](link)


### PR DESCRIPTION
Adding SEOengine.ai Black Friday deal with 35% OFF using code BLACKFRIDAY (valid Nov 17 - Dec 7). Features 5 AI agents, AEO-optimization, and E-E-A-T compliance.